### PR TITLE
Fix failure on installing large ipa: send packet (afc): write unix ->…

### DIFF
--- a/afc.go
+++ b/afc.go
@@ -289,7 +289,7 @@ func (c *afc) RemoveAll(path string) (err error) {
 	return
 }
 
-func (c *afc) WriteFile(filename string, data []byte, perm AfcFileMode) (err error) {
+func (c *afc) WriteFile(filename string, r io.Reader, perm AfcFileMode) (err error) {
 	var file *AfcFile
 	if file, err = c.Open(filename, perm); err != nil {
 		return err
@@ -298,7 +298,7 @@ func (c *afc) WriteFile(filename string, data []byte, perm AfcFileMode) (err err
 		err = file.Close()
 	}()
 
-	if _, err = file.Write(data); err != nil {
+	if _, err = io.Copy(file, r); err != nil {
 		return err
 	}
 	return

--- a/device.go
+++ b/device.go
@@ -414,12 +414,9 @@ func (d *device) AppInstall(ipaPath string) (err error) {
 
 	installationPath := path.Join(stagingPath, fmt.Sprintf("%s.ipa", bundleID))
 
-	var data []byte
-	if data, err = os.ReadFile(ipaPath); err != nil {
-		return err
-	}
-	if err = d.afc.WriteFile(installationPath, data, AfcFileModeWr); err != nil {
-		return err
+	if r, err := os.Open(ipaPath); err != nil {return err} else {
+		defer r.Close()
+		if err = d.afc.WriteFile(installationPath, r, AfcFileModeWr); err != nil {return err}
 	}
 
 	if _, err = d.installationProxyService(); err != nil {
@@ -831,7 +828,7 @@ func (d *device) _uploadXCTestConfiguration(bundleID string, sessionId uuid.UUID
 		return "", err
 	}
 
-	if err = appAfc.WriteFile(pathXCTestCfg, content, AfcFileModeWr); err != nil {
+	if err = appAfc.WriteFile(pathXCTestCfg, bytes.NewReader(content), AfcFileModeWr); err != nil {
 		return "", err
 	}
 

--- a/idevice.go
+++ b/idevice.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"time"
 
@@ -183,7 +184,7 @@ type Afc interface {
 	HashWithRange(filePath string, start, end uint64) ([]byte, error)
 	RemoveAll(path string) (err error)
 
-	WriteFile(filename string, data []byte, perm AfcFileMode) (err error)
+	WriteFile(filename string, r io.Reader, perm AfcFileMode) (err error)
 }
 
 type HouseArrest interface {


### PR DESCRIPTION
Fix failure on installing large ipa, in my case the file size is greater than 4GB
`send packet (afc): write unix ->/var/run/usbmuxd: write: broken pipe`